### PR TITLE
 Updating `configure` according to the MobX docs

### DIFF
--- a/documentation/homework/W4-homework.md
+++ b/documentation/homework/W4-homework.md
@@ -14,7 +14,7 @@ To use decorators (the `@` syntax) with `create-react-app`, follow this [tutoria
 
  _You must have MobX strict mode enabled. Any homework submitted without strict mode on will be rejected. You enable strict mode like this:_
  
-    configure({ enforceActions: true })
+    configure({ enforceActions: 'observed' })
 
 ## Scoring
 


### PR DESCRIPTION
According to the latest react course and the [docs](https://github.com/mobxjs/mobx/blob/master/CHANGELOG.md#510--440) of mobx, `configure({ enforceActions: true })` has been changed to be `configure({ enforceActions: 'observed' })` it takes multi kind of values depending to the use case But our use case case is the `'observed'` one.